### PR TITLE
Mark Groups API as deprecated

### DIFF
--- a/Source/Controllers/Groups/AddGroups.cs
+++ b/Source/Controllers/Groups/AddGroups.cs
@@ -10,6 +10,7 @@ using PoliFemoBackend.Source.Utils.Database;
 
 namespace PoliFemoBackend.Source.Controllers.Groups;
 
+[Obsolete("This endpoint will be removed with no replacement.")]
 [ApiController]
 [ApiExplorerSettings(GroupName = "Groups")]
 [Route("/groups")]

--- a/Source/Controllers/Groups/BackupJson.cs
+++ b/Source/Controllers/Groups/BackupJson.cs
@@ -10,6 +10,7 @@ using PoliFemoBackend.Source.Utils.Database;
 
 namespace PoliFemoBackend.Source.Controllers.Groups;
 
+[Obsolete("This endpoint will be removed with no replacement.")]
 [ApiController]
 [ApiExplorerSettings(GroupName = "Groups")]
 [Route("/groups/backup")]

--- a/Source/Controllers/Groups/ModifyGroup.cs
+++ b/Source/Controllers/Groups/ModifyGroup.cs
@@ -10,6 +10,7 @@ using PoliFemoBackend.Source.Utils.Groups;
 
 namespace PoliFemoBackend.Source.Controllers.Groups;
 
+[Obsolete("This endpoint will be removed with no replacement.")]
 [ApiController]
 [ApiExplorerSettings(GroupName = "Groups")]
 [Route("/groups/{id}")]

--- a/Source/Controllers/Groups/SearchGroups.cs
+++ b/Source/Controllers/Groups/SearchGroups.cs
@@ -10,6 +10,7 @@ using PoliFemoBackend.Source.Utils.Database;
 
 namespace PoliFemoBackend.Source.Controllers.Groups;
 
+[Obsolete("This endpoint will be removed with no replacement. Please use the JSON file to search for groups.")]
 [ApiController]
 [ApiExplorerSettings(GroupName = "Groups")]
 [Route("/groups")]


### PR DESCRIPTION
Dato che la fonte dei gruppi è il [file JSON](https://github.com/PoliNetworkOrg/polinetworkWebsiteData/blob/main/groupsGenerated.json), è inutile duplicarlo nel nostro db. Sarebbe meglio scaricare il file originale (e conservarlo in cache) con una ricerca client-side.

Una volta rimosse le chiamate a questa API, tutti gli endpoint verranno rimossi.