### PR TITLE
added explicit dep for OpenIDConnect

### DIFF
--- a/Backend/PoliFemoBackend.csproj
+++ b/Backend/PoliFemoBackend.csproj
@@ -44,7 +44,8 @@
         <PackageReference Include="ReverseMarkdown" Version="3.25.0"/>
         <PackageReference Include="SixLabors.ImageSharp" Version="3.0.2"/>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.32.3"/>
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Fixed dependabot update to jwt v7, known issue: https://stackoverflow.com/questions/77120928/why-do-i-get-idx20803-error-after-upgrading-to-identitymodel-v7-from-v6